### PR TITLE
Color list property values in Bases card views

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -150,6 +150,10 @@ export default class ColoredBasesPropertiesPlugin extends Plugin {
 			styleEl.sheet?.insertRule(
 				`.multi-select-pill[data-sanitized-content="${sanitizedContent}"] { background-color: ${color} !important; }`
 			);
+			// List property values rendered in Bases card views
+			styleEl.sheet?.insertRule(
+				`.bases-cards-line .value-list-element[data-sanitized-content="${sanitizedContent}"] { background-color: ${color} !important; color: white !important; }`
+			);
 		}
 		
 		if (this.settings.colorFormulaProperties) {
@@ -167,6 +171,9 @@ export default class ColoredBasesPropertiesPlugin extends Plugin {
 			if (this.settings.colorListProperties) {
 				styleEl.sheet?.insertRule(
 					`.internal-embed.bases-embed .multi-select-pill[data-sanitized-content="${sanitizedContent}"] { background-color: ${color} !important; }`
+				);
+				styleEl.sheet?.insertRule(
+					`.internal-embed.bases-embed .bases-cards-line .value-list-element[data-sanitized-content="${sanitizedContent}"] { background-color: ${color} !important; color: white !important; }`
 				);
 			}
 			
@@ -239,6 +246,14 @@ export default class ColoredBasesPropertiesPlugin extends Plugin {
 						const contentElement = element.querySelector('.multi-select-pill-content') as HTMLElement;
 						return contentElement?.textContent || element.textContent || '';
 					},
+					shouldSkip: () => false,
+				},
+				{
+					// List property values rendered in Bases card views use
+					// `.value-list-element` spans instead of `.multi-select-pill`.
+					enabled: this.settings.colorListProperties,
+					selector: '.bases-cards-line .value-list-element',
+					getTextContent: (element: HTMLDivElement) => element.textContent?.trim() || '',
 					shouldSkip: () => false,
 				},
 				{
@@ -510,6 +525,9 @@ export default class ColoredBasesPropertiesPlugin extends Plugin {
 						       element.classList?.contains('tag') ||
 						       element.querySelector?.('.bases-table-cell .tag') ||
 						       element.querySelector?.('.value-list-container .tag') ||
+						       // Watch for list values rendered in Bases cards
+						       element.classList?.contains('value-list-element') ||
+						       element.querySelector?.('.value-list-container .value-list-element') ||
 						       // Watch for embedded bases
 						       element.classList?.contains('internal-embed') ||
 						       element.classList?.contains('bases-embed') ||

--- a/styles.css
+++ b/styles.css
@@ -36,3 +36,19 @@ body .bases-table-cell .tag[data-sanitized-content] {
 	padding: 2px 8px;
 	text-decoration: none;
 }
+
+/* Base styles for list property values rendered in Bases cards */
+body .bases-cards-line .value-list-element[data-sanitized-content] {
+	transition: background-color 0.2s ease;
+	color: white;
+	border-radius: var(--pill-radius);
+	padding: 1px 8px;
+	display: inline-flex;
+	align-items: center;
+}
+body .bases-cards-line .value-list-container {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	align-items: center;
+}


### PR DESCRIPTION
## Summary

Adds coloring of **list property values in Bases _card_ views**. Currently the plugin colors list values in the properties panel and table views (`.multi-select-pill`, `.bases-table-cell ... .tag`), but card views render list values differently and were left uncolored.

## Why

In a Bases **card** view, a list/multitext property value is rendered as:

```html
<div class="bases-cards-line bases-rendered-value" data-property-type="multitext">
  <div class="value-list-container">
    <span class="value-list-element">Currently Playing</span>
  </div>
</div>
```

There's no `.multi-select-pill` or `.tag` here, so none of the existing selectors matched and card values stayed un-styled.

## Changes

- **`main.ts`**
  - New `propertyTypes` entry targeting `.bases-cards-line .value-list-element` (gated by `colorListProperties`).
  - `addColorRule`: inject a matching rule for card values (regular + embedded-bases variants). Reuses the existing `data-sanitized-content` mechanism, so `removeColorRule`/`updateColorRule` clean it up automatically.
  - Mutation observer now also watches for `.value-list-element` additions.
- **`styles.css`**: base pill chrome for `.bases-cards-line .value-list-element[data-sanitized-content]` (radius/padding/white text) and flex wrapping for the container.

## Notes

- Colors come from the existing per-value color map — no settings changes.
- Built locally with `npm run build` (tsc typecheck + esbuild) — passes. `main.js` is gitignored, so only source is included.